### PR TITLE
s22-6pm-4 Adrian - added field degradationRate to commons entity

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -29,6 +29,7 @@ public class Commons
   private double milkPrice;
   private double startingBalance;
   private LocalDateTime startingDate;
+  private double degradationRate;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",


### PR DESCRIPTION
This PR should ideally be merged after #40 as the full functionality depends on the fixtures files.

In this pull request we add a field degradationRate, as a double, to the commons database entity. All tests pass, there is 100% test coverage, and 100% mutation testing.

Closes #21