### PR TITLE
S22 6pm 3 dj - add leaderboard sorting utilities

### DIFF
--- a/frontend/src/main/utils/leaderboardSortingUtils.js
+++ b/frontend/src/main/utils/leaderboardSortingUtils.js
@@ -1,16 +1,20 @@
 import userCommonsFixtures from "../../fixtures/userCommonsFixtures"
 
 export function sortByWealth(userCommonsArray, returnArraySize = userCommonsArray.length){
-  //stub
-  return [];
+  return userCommonsArray.sort((a, b) => {
+    return a.totalWealth - b.totalWealth;
+  }).slice(0, returnArraySize);
 }
 
 export function sortByNumCows(userCommonsArray, returnArraySize = userCommonsArray.length){
-  //stub
-  return [];
+  return userCommonsArray.sort((a, b) => {
+    return a.numOfCows - b.numOfCows;
+  }).slice(0, returnArraySize);
 }
 
 export function sortByCowHealth(userCommonsArray, returnArraySize = userCommonsArray.length){
-  //stub
-  return [];
+  //sorts in decreasing order, so the comparison function returns a negative when the first parameter is larger
+  return userCommonsArray.sort((a, b) => {
+    return b.cowHealth - a.cowHealth;
+  }).slice(0, returnArraySize);
 }

--- a/frontend/src/main/utils/leaderboardSortingUtils.js
+++ b/frontend/src/main/utils/leaderboardSortingUtils.js
@@ -1,0 +1,16 @@
+import userCommonsFixtures from "../../fixtures/userCommonsFixtures"
+
+export function sortByWealth(userCommonsArray, returnArraySize = userCommonsArray.length){
+  //stub
+  return [];
+}
+
+export function sortByNumCows(userCommonsArray, returnArraySize = userCommonsArray.length){
+  //stub
+  return [];
+}
+
+export function sortByCowHealth(userCommonsArray, returnArraySize = userCommonsArray.length){
+  //stub
+  return [];
+}

--- a/frontend/src/main/utils/leaderboardSortingUtils.js
+++ b/frontend/src/main/utils/leaderboardSortingUtils.js
@@ -2,13 +2,13 @@ import userCommonsFixtures from "../../fixtures/userCommonsFixtures"
 
 export function sortByWealth(userCommonsArray, returnArraySize = userCommonsArray.length){
   return userCommonsArray.sort((a, b) => {
-    return a.totalWealth - b.totalWealth;
+    return b.totalWealth - a.totalWealth;
   }).slice(0, returnArraySize);
 }
 
 export function sortByNumCows(userCommonsArray, returnArraySize = userCommonsArray.length){
   return userCommonsArray.sort((a, b) => {
-    return a.numOfCows - b.numOfCows;
+    return b.numOfCows - a.numOfCows;
   }).slice(0, returnArraySize);
 }
 

--- a/frontend/src/main/utils/leaderboardSortingUtils.js
+++ b/frontend/src/main/utils/leaderboardSortingUtils.js
@@ -1,4 +1,3 @@
-import userCommonsFixtures from "../../fixtures/userCommonsFixtures"
 
 export function sortByWealth(userCommonsArray, returnArraySize = userCommonsArray.length){
   return userCommonsArray.sort((a, b) => {

--- a/frontend/src/tests/utils/leaderboardSortingUtils.test.js
+++ b/frontend/src/tests/utils/leaderboardSortingUtils.test.js
@@ -46,8 +46,46 @@ describe("leaderboardSortingUtils tests", () => {
   });
 
   //-----------------------------//
+  //      Num Cows Tests
+  //----------------------------//
+
+  test("sortByNumCows", () => {
+    const sortedUserCommons = sortByNumCows(fiveUserCommons);
+    const expectedNumCows = [1000, 100, 60, 8, 5];
+    for (i in expectedNumCows){
+      expect(sortedUserCommons[i].numOfCows).toBe(expectedNumCows[i]);
+    }
+  });
+
+  test("sortByNumCowsReturnOne", () => {
+    const sortedUserCommons = sortByNumCows(tenUserCommons, 1);
+    expect(sortedUserCommons.length).toBe(1);
+    expect(sortedUserCommons[0].numOfCows).toBe(1000);
+  });
+
+  test("sortByNumCowsReturnThree", () => {
+    const sortedUserCommons = sortByNumCows(tenUserCommons, 3);
+    expect(sortedUserCommons.length).toBe(3);
+    const expectedNumCows = [1000, 1000, 100];
+    for (i in expectedNumCows){
+      expect(sortedUserCommons[i].numOfCows).toBe(expectedNumCows[i]);
+    }
+  });
+
+  // Expected behavior here is to just return the full sorted array of userCommons
+  test("sortByNumCowsExpectTooMany", () => {
+    const sortedUserCommons = sortByNumCows(tenUserCommons, 25);
+    expect(sortedUserCommons.length).toBe(tenUserCommons.length);
+    const expectedNumCows = [1000, 1000, 100, 100, 60, 60, 8, 8, 5, 5];
+    for (i in expectedNumCows){
+      expect(sortedUserCommons[i].numOfCows).toBe(expectedNumCows[i]);
+    }
+  });
+
+  //-----------------------------//
   //      Cow Health Tests
   //----------------------------//
+  // if tests fail due to floating point error, try using .toBeCloseTo(number, numDigits?) instead of .toBe()
 
   test("sortByCowHealth", () => {
     const sortedUserCommons = sortByCowHealth(fiveUserCommons);
@@ -60,13 +98,13 @@ describe("leaderboardSortingUtils tests", () => {
   test("sortByCowHealthReturnOne", () => {
     const sortedUserCommons = sortByCowHealth(tenUserCommons, 1);
     expect(sortedUserCommons.length).toBe(1);
-    expect(sortedUserCommons[0].cowHealth).toBe(100000);
+    expect(sortedUserCommons[0].cowHealth).toBe(98.0);
   });
 
   test("sortByCowHealthReturnThree", () => {
     const sortedUserCommons = sortByCowHealth(tenUserCommons, 3);
     expect(sortedUserCommons.length).toBe(3);
-    const expectedCowHealths = [100000, 100000, 1000];
+    const expectedCowHealths = [98.0, 98.0, 93.0];
     for (i in expectedCowHealths){
       expect(sortedUserCommons[i].cowHealth).toBe(expectedCowHealths[i]);
     }
@@ -76,7 +114,7 @@ describe("leaderboardSortingUtils tests", () => {
   test("sortByCowHealthExpectTooMany", () => {
     const sortedUserCommons = sortByCowHealth(tenUserCommons, 25);
     expect(sortedUserCommons.length).toBe(tenUserCommons.length);
-    const expectedCowHealths = [100000, 100000, 1000, 1000, 1000, 1000, 800, 800, 50, 50];
+    const expectedCowHealths = [98.0, 98.0, 93.0, 93.0, 84.0, 84.0, 72.0, 72.0, 2.0, 2.0, ];
     for (i in expectedCowHealths){
       expect(sortedUserCommons[i].cowHealth).toBe(expectedCowHealths[i]);
     }

--- a/frontend/src/tests/utils/leaderboardSortingUtils.test.js
+++ b/frontend/src/tests/utils/leaderboardSortingUtils.test.js
@@ -3,8 +3,8 @@ import userCommonsFixtures from "../../fixtures/userCommonsFixtures"
 
 describe("leaderboardSortingUtils tests", () => {
   const {
-    oneUserCommons,
-    threeUserCommons,
+    _oneUserCommons,
+    _threeUserCommons,
     fiveUserCommons,
     tenUserCommons
   } = userCommonsFixtures;

--- a/frontend/src/tests/utils/leaderboardSortingUtils.test.js
+++ b/frontend/src/tests/utils/leaderboardSortingUtils.test.js
@@ -1,0 +1,46 @@
+import { sortByWealth, sortByNumCows, sortByCowHealth } from "../../main/utils/leaderboardSortingUtils"
+import userCommonsFixtures from "../../fixtures/userCommonsFixtures"
+
+describe("leaderboardSortingUtils tests", () => {
+  const {
+    oneUserCommons,
+    threeUserCommons,
+    fiveUserCommons,
+    tenUserCommons
+  } = userCommonsFixtures;
+
+  test("sortByWealth", () => {
+    const sortedUserCommons = sortByWealth(fiveUserCommons);
+    const expectedWealths = [100000, 1000, 1000, 800, 50];
+    for (i in expectedWealths){
+      expect(sortedUserCommons[i].totalWealth).toBe(expectedWealths[i]);
+    }
+  });
+
+  test("sortByWealthReturnOne", () => {
+    const sortedUserCommons = sortByWealth(tenUserCommons, 1);
+    expect(sortedUserCommons.length).toBe(1);
+    expect(sortedUserCommons[0].totalWealth).toBe(100000);
+  });
+
+  test("sortByWealthReturnThree", () => {
+    const sortedUserCommons = sortByWealth(tenUserCommons, 3);
+    expect(sortedUserCommons.length).toBe(3);
+    const expectedWealths = [100000, 100000, 1000];
+    for (i in expectedWealths){
+      expect(sortedUserCommons[i].totalWealth).toBe(expectedWealths[i]);
+    }
+  });
+
+  // Expected behavior here is to just return the full sorted array of userCommons
+  test("sortByWealthExpectTooMany", () => {
+    const sortedUserCommons = sortByWealth(tenUserCommons, 25);
+    expect(sortedUserCommons.length).toBe(tenUserCommons.length);
+    const expectedWealths = [100000, 100000, 1000, 1000, 1000, 1000, 800, 800, 50, 50];
+    for (i in expectedWealths){
+      expect(sortedUserCommons[i].totalWealth).toBe(expectedWealths[i]);
+    }
+  });
+
+
+})

--- a/frontend/src/tests/utils/leaderboardSortingUtils.test.js
+++ b/frontend/src/tests/utils/leaderboardSortingUtils.test.js
@@ -9,6 +9,9 @@ describe("leaderboardSortingUtils tests", () => {
     tenUserCommons
   } = userCommonsFixtures;
 
+//-----------------------------//
+//        Wealth Tests
+//----------------------------//
   test("sortByWealth", () => {
     const sortedUserCommons = sortByWealth(fiveUserCommons);
     const expectedWealths = [100000, 1000, 1000, 800, 50];
@@ -39,6 +42,43 @@ describe("leaderboardSortingUtils tests", () => {
     const expectedWealths = [100000, 100000, 1000, 1000, 1000, 1000, 800, 800, 50, 50];
     for (i in expectedWealths){
       expect(sortedUserCommons[i].totalWealth).toBe(expectedWealths[i]);
+    }
+  });
+
+  //-----------------------------//
+  //      Cow Health Tests
+  //----------------------------//
+
+  test("sortByCowHealth", () => {
+    const sortedUserCommons = sortByCowHealth(fiveUserCommons);
+    const expectedCowHealths = [98.0, 93.0, 84.0, 72.0, 2.0];
+    for (i in expectedCowHealths){
+      expect(sortedUserCommons[i].cowHealth).toBe(expectedCowHealths[i]);
+    }
+  });
+
+  test("sortByCowHealthReturnOne", () => {
+    const sortedUserCommons = sortByCowHealth(tenUserCommons, 1);
+    expect(sortedUserCommons.length).toBe(1);
+    expect(sortedUserCommons[0].cowHealth).toBe(100000);
+  });
+
+  test("sortByCowHealthReturnThree", () => {
+    const sortedUserCommons = sortByCowHealth(tenUserCommons, 3);
+    expect(sortedUserCommons.length).toBe(3);
+    const expectedCowHealths = [100000, 100000, 1000];
+    for (i in expectedCowHealths){
+      expect(sortedUserCommons[i].cowHealth).toBe(expectedCowHealths[i]);
+    }
+  });
+
+  // Expected behavior here is to just return the full sorted array of userCommons
+  test("sortByCowHealthExpectTooMany", () => {
+    const sortedUserCommons = sortByCowHealth(tenUserCommons, 25);
+    expect(sortedUserCommons.length).toBe(tenUserCommons.length);
+    const expectedCowHealths = [100000, 100000, 1000, 1000, 1000, 1000, 800, 800, 50, 50];
+    for (i in expectedCowHealths){
+      expect(sortedUserCommons[i].cowHealth).toBe(expectedCowHealths[i]);
     }
   });
 

--- a/frontend/src/tests/utils/leaderboardSortingUtils.test.js
+++ b/frontend/src/tests/utils/leaderboardSortingUtils.test.js
@@ -15,7 +15,7 @@ describe("leaderboardSortingUtils tests", () => {
   test("sortByWealth", () => {
     const sortedUserCommons = sortByWealth(fiveUserCommons);
     const expectedWealths = [100000, 1000, 1000, 800, 50];
-    for (i in expectedWealths){
+    for (let i in expectedWealths){
       expect(sortedUserCommons[i].totalWealth).toBe(expectedWealths[i]);
     }
   });
@@ -30,7 +30,7 @@ describe("leaderboardSortingUtils tests", () => {
     const sortedUserCommons = sortByWealth(tenUserCommons, 3);
     expect(sortedUserCommons.length).toBe(3);
     const expectedWealths = [100000, 100000, 1000];
-    for (i in expectedWealths){
+    for (let i in expectedWealths){
       expect(sortedUserCommons[i].totalWealth).toBe(expectedWealths[i]);
     }
   });
@@ -40,7 +40,7 @@ describe("leaderboardSortingUtils tests", () => {
     const sortedUserCommons = sortByWealth(tenUserCommons, 25);
     expect(sortedUserCommons.length).toBe(tenUserCommons.length);
     const expectedWealths = [100000, 100000, 1000, 1000, 1000, 1000, 800, 800, 50, 50];
-    for (i in expectedWealths){
+    for (let i in expectedWealths){
       expect(sortedUserCommons[i].totalWealth).toBe(expectedWealths[i]);
     }
   });
@@ -52,7 +52,7 @@ describe("leaderboardSortingUtils tests", () => {
   test("sortByNumCows", () => {
     const sortedUserCommons = sortByNumCows(fiveUserCommons);
     const expectedNumCows = [1000, 100, 60, 8, 5];
-    for (i in expectedNumCows){
+    for (let i in expectedNumCows){
       expect(sortedUserCommons[i].numOfCows).toBe(expectedNumCows[i]);
     }
   });
@@ -67,7 +67,7 @@ describe("leaderboardSortingUtils tests", () => {
     const sortedUserCommons = sortByNumCows(tenUserCommons, 3);
     expect(sortedUserCommons.length).toBe(3);
     const expectedNumCows = [1000, 1000, 100];
-    for (i in expectedNumCows){
+    for (let i in expectedNumCows){
       expect(sortedUserCommons[i].numOfCows).toBe(expectedNumCows[i]);
     }
   });
@@ -77,7 +77,7 @@ describe("leaderboardSortingUtils tests", () => {
     const sortedUserCommons = sortByNumCows(tenUserCommons, 25);
     expect(sortedUserCommons.length).toBe(tenUserCommons.length);
     const expectedNumCows = [1000, 1000, 100, 100, 60, 60, 8, 8, 5, 5];
-    for (i in expectedNumCows){
+    for (let i in expectedNumCows){
       expect(sortedUserCommons[i].numOfCows).toBe(expectedNumCows[i]);
     }
   });
@@ -90,7 +90,7 @@ describe("leaderboardSortingUtils tests", () => {
   test("sortByCowHealth", () => {
     const sortedUserCommons = sortByCowHealth(fiveUserCommons);
     const expectedCowHealths = [98.0, 93.0, 84.0, 72.0, 2.0];
-    for (i in expectedCowHealths){
+    for (let i in expectedCowHealths){
       expect(sortedUserCommons[i].cowHealth).toBe(expectedCowHealths[i]);
     }
   });
@@ -105,7 +105,7 @@ describe("leaderboardSortingUtils tests", () => {
     const sortedUserCommons = sortByCowHealth(tenUserCommons, 3);
     expect(sortedUserCommons.length).toBe(3);
     const expectedCowHealths = [98.0, 98.0, 93.0];
-    for (i in expectedCowHealths){
+    for (let i in expectedCowHealths){
       expect(sortedUserCommons[i].cowHealth).toBe(expectedCowHealths[i]);
     }
   });
@@ -115,7 +115,7 @@ describe("leaderboardSortingUtils tests", () => {
     const sortedUserCommons = sortByCowHealth(tenUserCommons, 25);
     expect(sortedUserCommons.length).toBe(tenUserCommons.length);
     const expectedCowHealths = [98.0, 98.0, 93.0, 93.0, 84.0, 84.0, 72.0, 72.0, 2.0, 2.0, ];
-    for (i in expectedCowHealths){
+    for (let i in expectedCowHealths){
       expect(sortedUserCommons[i].cowHealth).toBe(expectedCowHealths[i]);
     }
   });


### PR DESCRIPTION
# Overview

This PR includes functions that sort an array of UserCommons by wealth, number of cows and cow health. Each function includes an optional parameter to only return the top N elements of the array. This will be useful for feeding data into the leaderboard, especially when only a limited number of UserCommons should be displayed.

Also included are tests for these functions, which use the UserCommons features made earlier.

# Issues Addressed

This closes Issue #39 (Write sorting logic for leaderboard table)

# Test Plan (for interactive testing)

These are just javascript utilities, so to test them yourself, make an array of mock UserCommons (or use the userCommons features that already exist) and run the functions on them. 

You can also run the automated tests, which give the following results:

Code Coverage: 
![image](https://user-images.githubusercontent.com/72847482/171328472-409c0b4d-10d4-402e-b0fc-2c6dca704b83.png)
![image](https://user-images.githubusercontent.com/72847482/171328512-07535566-3366-467d-b95a-1213a9f54da7.png)

Stryker testing:
![image](https://user-images.githubusercontent.com/72847482/171328313-bbed1ec1-2669-4033-b103-5e3004a46860.png)