### PR TITLE
pc - add link to dashboard for production heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * [Docs](https://ucsb-cs156-s22.github.io/s22-6pm-happycows-docs/)
 
 # Heroku
-* [Production](https://s22-6pm-happycows.herokuapp.com/)
+* [Production](https://s22-6pm-happycows.herokuapp.com/) [Dashboard](https://dashboard.heroku.com/apps/s22-6pm-happycows)
 
 6pm-3:
 * [QA](https://s22-6pm-3-happycows-qa.herokuapp.com/)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 * [Docs](https://ucsb-cs156-s22.github.io/s22-6pm-happycows-docs/)
 
 # Heroku
-* [Production](https://s22-6pm-happycows.herokuapp.com/) [Dashboard](https://dashboard.heroku.com/apps/s22-6pm-happycows)
+* [Production](https://s22-6pm-happycows.herokuapp.com/)
+* [Dashboard](https://dashboard.heroku.com/apps/s22-6pm-happycows)
 
 6pm-3:
 * [QA](https://s22-6pm-3-happycows-qa.herokuapp.com/)


### PR DESCRIPTION
# Overview

In this PR, we add a link to the dashboard for the Heroku production site.

# Screenshots

Before:

<img width="534" alt="image" src="https://user-images.githubusercontent.com/1119017/171443093-4d8d2ea5-1931-4d0c-bc3c-3dc6fa87e2b9.png">


After:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/1119017/171443333-94e40650-aae8-47dd-94aa-3c697e1902af.png">

# Test plan

1. Go to README on this branch: 
    https://github.com/ucsb-cs156-s22/s22-6pm-happycows/blob/staff-s22-pc-add-heroku-dashboard-link/README.md
2. Click new link and make sure it goes to the correct link.