### PR TITLE
s22-6pm-3 as- Added GetUserCommonsByCommonsId to backend (CherryPicked)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -186,4 +186,5 @@ public class CommonsController extends ApiController {
     userCommonsRepository.deleteById(userCommons.getId());
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
+
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -126,7 +126,7 @@ public class UserCommonsController extends ApiController {
         @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
       Iterable<UserCommons> uc = userCommonsRepository.findByCommonsId(commonsId);
       
-      //  Iterable<UserCommons> uc =  userCommonsRepository.findAll());
+   
     String body = mapper.writeValueAsString(uc);
     return ResponseEntity.ok().body(body);
   }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -119,6 +119,16 @@ public class UserCommonsController extends ApiController {
         return ResponseEntity.ok().body(body);
     }
 
-    
+    @ApiOperation(value = "Get all user commons for a specific commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/commons/all")
+    public  ResponseEntity<String> getUsersCommonsByCommonsId(
+        @ApiParam("commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+      Iterable<UserCommons> uc = userCommonsRepository.findByCommonsId(commonsId);
+      
+      //  Iterable<UserCommons> uc =  userCommonsRepository.findAll());
+    String body = mapper.writeValueAsString(uc);
+    return ResponseEntity.ok().body(body);
+  }
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
@@ -10,6 +10,6 @@ import edu.ucsb.cs156.happiercows.entities.UserCommons;
 @Repository
 public interface UserCommonsRepository extends CrudRepository<UserCommons, Long> {
     Optional<UserCommons> findByCommonsIdAndUserId(Long commonsId, Long userId );
-
+    Iterable<UserCommons> findByCommonsId(Long commonsId);
     void deleteAllByCommonsId(Long commonsId);
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -475,4 +475,5 @@ public class CommonsControllerTests extends ControllerTestCase {
       "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.Exception: UserCommons with commonsId=2 and userId=1 not found.");
     }
   }
+  
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -723,7 +723,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       expectedUserCommons.add(testexpectedUserCommons);
       when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
   
-      MvcResult response = mockMvc.perform(get("/api/usercommons//commons/all?commonsId=1"))
+      MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
           .andExpect(status().isOk()).andReturn();
   
       verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -712,4 +712,25 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       String responseString = response.getResponse().getContentAsString();
       assertEquals(expectedReturn, responseString);
     }
+
+
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void test_getAllUserCommonsById_exists() throws Exception {
+        List<UserCommons> expectedUserCommons = new ArrayList<UserCommons>();
+      UserCommons testexpectedUserCommons = dummyUserCommons(1);
+      expectedUserCommons.add(testexpectedUserCommons);
+      when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
+  
+      MvcResult response = mockMvc.perform(get("/api/usercommons//commons/all?commonsId=1"))
+          .andExpect(status().isOk()).andReturn();
+  
+      verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
+  
+      String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+      String responseString = response.getResponse().getContentAsString();
+  
+      assertEquals(expectedJson, responseString);
+    }
 }


### PR DESCRIPTION
# Overview
Resolves Issue #38 
I added getUsersCommonsByCommonsId to the UserCommonsController which outputs the userCommons associated with a given commonsId.

Sample Output for when commons exists:
![image](https://user-images.githubusercontent.com/72825220/171324328-a49ab416-dcda-4ced-a94a-d0d74e3b6b00.png)
Sample Output for when commons does not exist:
![image](https://user-images.githubusercontent.com/72825220/171324705-7bbd75e2-d44b-4b7d-9071-8a2b97e007ca.png)

Jacoco Report:
![image](https://user-images.githubusercontent.com/72825220/171324549-2c43141c-0818-49aa-a400-30c4fab7b49b.png)

Mutation Testing:
![image](https://user-images.githubusercontent.com/72825220/171324376-d6c0c324-92f8-4f8f-b711-fb1331bdd182.png)
