### PR TITLE
s22-6pm-4 lv - Show Leaderboard column in CommonsTable

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminCreateCommonsPage from "main/pages/AdminCreateCommonsPage";
 import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
 import AdminListCommonsPage from "main/pages/AdminListCommonPage";
+import LeaderboardPage from "main/pages/LeaderboardPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 
@@ -35,6 +36,9 @@ function App() {
         }
         {
           hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/leaderboard/:id" element={<LeaderboardPage />} />
         }
         <Route path="/play/:commonsId" element={<PlayPage />} />
       </Routes>

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -24,6 +24,10 @@ export default function CommonsTable({ commons, currentUser }) {
     // Stryker disable next-line all : TODO try to make a good test for this
     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
+    const leaderboardCallback = (cell) => {
+        navigate(`/admin/leaderboard/${cell.row.values.id}`)
+    }
+
     const columns = [
         {
             Header: 'id',
@@ -62,7 +66,8 @@ export default function CommonsTable({ commons, currentUser }) {
     const columnsIfAdmin = [
         ...columns,
         ButtonColumn("Edit", "primary", editCallback, testid),
-        ButtonColumn("Delete", "danger", deleteCallback, testid)
+        ButtonColumn("Delete", "danger", deleteCallback, testid),
+        ButtonColumn("Leaderboard", "secondary", leaderboardCallback, testid)
     ];
 
     const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -1,0 +1,17 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+
+export default function CommonsEditPage() {
+  let { id } = useParams();
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Leaderboard</h1>
+        <p>
+            This is where the leaderboard for commons with id {id} will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -163,4 +163,28 @@ describe("AdminListCommonPage tests", () => {
 
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/editcommons/5'));
     });
+
+    test("what happens when you click leaderboard as an admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.threeCommons);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5");
+      
+        const leaderboardButton = screen.getByTestId(`${testId}-cell-row-0-col-Leaderboard-button`);
+        expect(leaderboardButton).toBeInTheDocument();
+
+        fireEvent.click(leaderboardButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/leaderboard/5'));
+    })
 });

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import LeaderboardPage from "main/pages/LeaderboardPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import usersFixtures from "fixtures/usersFixtures";
+
+describe("LeaderboardPage tests",  () => {
+    const queryClient = new QueryClient();
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(()=>{
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/admin/users").reply(200, usersFixtures.threeUsers);
+
+    });
+
+    test("renders without crashing on two users", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByText("Leaderboard")).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
In this PR, I've added a button for admins in CommonsTable that navigates to the leaderboard page for a particular commons id. I've also added a placeholder for LeaderboardPage, since none existed yet. I've also updated the tests for AdminListCommonsPage to cover the Leaderboard button, and put tests for the LeaderboardPage placeholder to ensure complete code coverage.

# Screenshots

Before:

There is no leaderboard button in the CommonsTable
<img width="1307" alt="image" src="https://user-images.githubusercontent.com/72827930/171529840-c68b4710-21af-48f5-8d90-9b69b96cf083.png">

After:

The leaderboard button appears in the CommonsTable
<img width="1317" alt="image" src="https://user-images.githubusercontent.com/72827930/171529658-fa8f0c04-df5c-430b-bfd9-1b0904e8d79a.png">

There is a placeholder Leaderboard page:
<img width="1311" alt="image" src="https://user-images.githubusercontent.com/72827930/171529713-b227cea2-15a2-4b2b-a1b3-4013cbfacf35.png">

Frontend tests  all pass and have full code and mutation coverage:
<img width="682" alt="image" src="https://user-images.githubusercontent.com/72827930/171530067-1604b2c3-e101-44b3-8298-2d280cf8825a.png">
<img width="653" alt="image" src="https://user-images.githubusercontent.com/72827930/171530118-2da572a6-68b8-4d59-9a7f-8c88ea0841be.png">
<img width="745" alt="image" src="https://user-images.githubusercontent.com/72827930/171530356-8f9d2d69-5a4c-4a75-935e-7cd4e63af132.png">

# Test Plan

Go to the List Commons page as an Admin, and make sure that the CommonsTable displays a button that says "Leaderboard" in each row of the table. When this button is clicked, check that it navigates to the leaderboard page for the commons with the correct id.

Closes #17
