### PR TITLE
s22-6pm-4 Adrian display field starting date as YYYY-MM-DD in CommonsTable for readability

### DIFF
--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -51,8 +51,7 @@ export default function CommonsTable({ commons, currentUser }) {
         },
         {
             Header:'Starting Date',
-            //accessor: row => row.startingDate.toString(),
-            accessor: row => String(row.startingDate),
+            accessor: row => String(row.startingDate).slice(0,10),
             id: 'startingDate'
         }
     ];


### PR DESCRIPTION
In this PR, we modify CommonsTable.js to display the field startingDate in the format YYYY-MM-DD. This improves readability and the experience of the admin user. All tests pass, there is 100% test coverage, and there is 100% mutation testing.
Before:
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/72310805/171552189-04ea887e-c48f-44b1-b769-1e157f5c99c6.png">
After:
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/72310805/171551947-c3a63209-f964-4035-bc00-9d0e920abf78.png">

Closes #65 