### PR TITLE
Dj add end date to commons backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -86,6 +86,7 @@ public class CommonsController extends ApiController {
     updated.setMilkPrice(params.getMilkPrice());
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
+    updated.setEndingDate(params.getEndingDate());
 
     commonsRepository.save(updated);
 
@@ -117,6 +118,7 @@ public class CommonsController extends ApiController {
       .milkPrice(params.getMilkPrice())
       .startingBalance(params.getStartingBalance())
       .startingDate(params.getStartingDate())
+      .endingDate(params.getEndingDate())
       .build();
 
     Commons saved = commonsRepository.save(commons);
@@ -161,9 +163,9 @@ public class CommonsController extends ApiController {
   @DeleteMapping("")
   public Object deleteCommons(
           @ApiParam("id") @RequestParam Long id) {
-      
+
       Commons foundCommons = commonsRepository.findById(id).orElseThrow( ()->new EntityNotFoundException(Commons.class, id));
- 
+
       commonsRepository.deleteById(id);
       userCommonsRepository.deleteAllByCommonsId(id);
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -29,6 +29,7 @@ public class Commons
   private double milkPrice;
   private double startingBalance;
   private LocalDateTime startingDate;
+  private LocalDateTime endingDate;
   private double degradationRate;
   private boolean showLeaderboard;
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -27,4 +27,5 @@ public class CreateCommonsParams
   @NumberFormat private double milkPrice;
   @NumberFormat private double startingBalance;
   @DateTimeFormat private LocalDateTime startingDate;
+  @DateTimeFormat private LocalDateTime endingDate;
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -67,6 +67,7 @@ public class CommonsControllerTests extends ControllerTestCase {
   public void createCommonsTest() throws Exception
   {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
 
     Commons commons = Commons.builder()
       .name("Jackson's Commons")
@@ -74,6 +75,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .endingDate(someOtherTime)
       .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -82,6 +84,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .endingDate(someOtherTime)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -128,6 +131,7 @@ public class CommonsControllerTests extends ControllerTestCase {
   public void updateCommonsTest() throws Exception
   {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
       .name("Jackson's Commons")
@@ -135,6 +139,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .endingDate(someOtherTime)
       .build();
 
     Commons commons = Commons.builder()
@@ -143,6 +148,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
+      .endingDate(someOtherTime)
       .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -366,31 +372,34 @@ public class CommonsControllerTests extends ControllerTestCase {
   @Test
   public void deleteCommons_test_admin_exists() throws Exception {
       LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+      LocalDateTime someOtherTime = LocalDateTime.parse("2022-04-20T15:50:10");
+
       Commons c = Commons.builder()
         .name("Jackson's Commons")
         .cowPrice(500.99)
         .milkPrice(8.99)
         .startingBalance(1020.10)
         .startingDate(someTime)
+        .endingDate(someOtherTime)
         .build();
-      
+
       when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));
       doNothing().when(commonsRepository).deleteById(2L);
       doNothing().when(userCommonsRepository).deleteAllByCommonsId(2L);
 
-      
+
       MvcResult response = mockMvc.perform(
               delete("/api/commons?id=2")
                       .with(csrf()))
               .andExpect(status().is(200)).andReturn();
-      
+
       verify(commonsRepository, times(1)).findById(2L);
       verify(commonsRepository, times(1)).deleteById(2L);
       verify(userCommonsRepository, times(1)).deleteAllByCommonsId(2L);
 
       String responseString = response.getResponse().getContentAsString();
-      
-      String expectedString = "{\"message\":\"commons with id 2 deleted\"}"; 
+
+      String expectedString = "{\"message\":\"commons with id 2 deleted\"}";
 
       assertEquals(expectedString, responseString);
   }
@@ -398,27 +407,27 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void deleteCommons_test_admin_nonexists() throws Exception {
-      
+
       when(commonsRepository.findById(eq(2L))).thenReturn(Optional.empty());
-      
+
       MvcResult response = mockMvc.perform(
               delete("/api/commons?id=2")
                       .with(csrf()))
               .andExpect(status().is(404)).andReturn();
-      
       verify(commonsRepository, times(1)).findById(2L);
-      
+
+
 
       String responseString = response.getResponse().getContentAsString();
-      
+
       String expectedString = "{\"message\":\"Commons with id 2 not found\",\"type\":\"EntityNotFoundException\"}";
-      
+
       Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
       Map<String, Object> jsonResponse = responseToJson(response);
       assertEquals(expectedJson, jsonResponse);
   }
-  
-  
+
+
   @WithMockUser(roles = {"ADMIN"})
   @Test
   public void deleteUserFromCommonsTest() throws Exception {


### PR DESCRIPTION
# Overview

Adds an endDate field to Commons backend.
This time, this branch was made off of the main branch, instead of another PR. 

# Issues Addressed

Addresses Issue #57 

# Details

The Commons backend api now returns an endDate for each commons, which could be used in the future to implement a countdown for the number of days left in a commons.

# Test Plan (for interactive testing)

* Load the page onto localhost:8080
* Go to the Swagger UI page
* Use sample PUT and GET requests to confirm that you get an endDate

Coverage:
![image](https://user-images.githubusercontent.com/72847482/171586022-8c44677e-b66c-40f3-8c3d-9e8779e1a56e.png)

Mutation testing:
![image](https://user-images.githubusercontent.com/72847482/171586089-8e5aed8b-aa38-4a9e-8b64-83eef1c2af38.png)
