### PR TITLE
s22-6pm-3 hide and show leaderboard button appropriately

### DIFF
--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -1,24 +1,28 @@
 import React from "react";
-import {  Row, Card, Col, Button } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
+import { _Container, Row, _Router, Card, Col, Button } from "react-bootstrap";
+import { _Link, useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
 
-export default function CommonsOverview({ commons }) {
-    
+export default function CommonsOverview({ commons, currentUser }) {
+
     let navigate = useNavigate();
     // Stryker disable next-line all
     const leaderboardButtonClick = () => { navigate("/leaderboard/" + commons.id) };
-
+    const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
     return (
         <Card data-testid="CommonsOverview">
             <Card.Header as="h5">Announcements</Card.Header>
             <Card.Body>
                 <Row>
                     <Col>
-                    <Card.Title>Today is day {commons.day}! This game will end on {commons.endDate}.</Card.Title>
-                    <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
+                        <Card.Title>Today is day {commons.day}! This game will end on {commons.endDate}.</Card.Title>
+                        <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
                     </Col>
                     <Col>
-                        <Button variant="outline-success" data-testid="user-leaderboard-button" onClick={leaderboardButtonClick}>Leaderboard</Button>
+                        {showLeaderboard &&
+                        (<Button variant="outline-success" data-testid="user-leaderboard-button" onClick={leaderboardButtonClick}>
+                            Leaderboard
+                        </Button>)}
                     </Col>
                 </Row>
             </Card.Body>

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { _Container, Row, _Router, Card, Col, Button } from "react-bootstrap";
-import { _Link, useNavigate } from "react-router-dom";
+import { Row, Card, Col, Button } from "react-bootstrap";
+import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
 export default function CommonsOverview({ commons, currentUser }) {

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { useParams } from "react-router-dom";
-
+import { hasRole } from "main/utils/currentUser";
 
 import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
@@ -31,12 +31,32 @@ export default function LeaderboardPage() {
     );
   // Stryker enable all 
 
+  // Stryker disable all 
+  const { data: commons, error: _commonsError, status: _commonsStatus } =
+    useBackend(
+      [`/api/commons?id=${commonsId}`],
+      {
+        method: "GET",
+        url: "/api/commons",
+        params: {
+          id: commonsId
+        }
+      },
+      []
+    );
+  // Stryker enable all 
+
+  const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>
-                <LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />
+                {
+                  showLeaderboard?
+                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
+                  (<p>You're not authorized to see the leaderboard.</p>)
+                }
             </div>
         </BasicLayout>
     </div>

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -125,7 +125,7 @@ export default function PlayPage() {
       <BasicLayout >
         <Container >
           {!!currentUser && <CommonsPlay currentUser={currentUser} />}
-          {!!commons && <CommonsOverview commons={commons} />}
+          {!!commons && <CommonsOverview commons={commons} currentUser={currentUser} />}
           <br />
           {!!userCommons &&
             <CardGroup >

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -11,13 +11,6 @@ import leaderboardFixtures from "fixtures/leaderboardFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
-// jest.mock("react-router-dom", () => ({
-//     ...jest.requireActual("react-router-dom"),
-//     useParams: () => ({
-//         commonsId: 1
-//     })
-// }));
-
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { screen, waitFor, render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
@@ -19,16 +19,22 @@ jest.mock('react-toastify', () => {
     };
 });
 
-const mockedNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useNavigate: () => mockedNavigate
-}));
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            commonsId: 1
+        }),
+        useNavigate: () => mockNavigate
+    };
+});
 
 describe("LeaderboardPage tests", () => {
     
     const axiosMock = new AxiosMockAdapter(axios);
-
 
     const setupUser = () => {
         axiosMock.reset();
@@ -46,38 +52,6 @@ describe("LeaderboardPage tests", () => {
 
     test("renders without crashing for users", () => {
         setupUser();
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/commons/all").reply(200, []);
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <LeaderboardPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-    });
-
-    test("renders without crashing for admin", () => {
-        setupAdmin();
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/commons/all").reply(200, []);
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <LeaderboardPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-    });
-    
-    beforeEach(() => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
         axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
             "id": 1,
             "name": "Anika's Commons",
@@ -91,5 +65,84 @@ describe("LeaderboardPage tests", () => {
             "degradationRate": .5,
             "showLeaderboard": true,
         });
+        axiosMock.onGet("/api/usercommons/commons/all", { params: { commonsId: 1} }).reply(200,[]);
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
     });
+
+    test("renders leaderboard for users when showLeaderboard = true", async () => {
+        setupUser();
+        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
+            "id": 1,
+            "name": "Anika's Commons",
+            "day": 5,
+            "startingDate": "2026-03-05T15:50:10",
+            "endDate": "2027-03-05T15:50:10",
+            "startingBalance": 200.50,
+            "totalPlayers": 50,
+            "cowPrice": 15,
+            "milkPrice": 10,
+            "degradationRate": .5,
+            "showLeaderboard": true,
+        });
+        axiosMock.onGet("/api/usercommons/commons/all", { params: { commonsId: 1} }).reply(200,[]);
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        await waitFor(() => {
+            expect(axiosMock.history.get.length).toEqual(4);
+        });
+        expect(await screen.findByText("Total Wealth")).toBeInTheDocument();
+    });
+
+    test("renders leaderboard error message for users when showLeaderboard = false", async () => {
+        setupUser();
+        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
+            "id": 1,
+            "name": "Anika's Commons",
+            "day": 5,
+            "startingDate": "2026-03-05T15:50:10",
+            "endDate": "2027-03-05T15:50:10",
+            "startingBalance": 200.50,
+            "totalPlayers": 50,
+            "cowPrice": 15,
+            "milkPrice": 10,
+            "degradationRate": .5,
+            "showLeaderboard": false,
+        });
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByText("You're not authorized to see the leaderboard.")).toBeInTheDocument();
+    });
+
+    test("renders without crashing for admin", () => {
+        setupAdmin();
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+
 });


### PR DESCRIPTION
In this pull request we hide the leaderboard button when the user should not have access to the leaderboard.
Also, on the leaderboard page, if an ordinary user attempts to navigate to the page without having access, the page should now display an error message that states they do not have access.

# Testing Plan

1. create a commons with the show leaderboard off
2. visit the commons as a non admin user
3. you should see no leaderboard button
4. log in as an admin
5. turn leaderboard on
6. log in as regular user again
7. leaderboard button should appear

# Testing Plan (pt 2)

 same plan but go to the url directly /leaderboard/commonsId

you should see a leaderboard when allowed and an error message when not