### PR TITLE
m22 - sk - (recreate 4pm PR92) fix initialization of cow number to start at 0 instead of 1

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -159,7 +159,7 @@ public class CommonsController extends ApiController {
         .commonsId(commonsId)
         .userId(userId)
         .totalWealth(joinedCommons.getStartingBalance())
-        .numOfCows(1)
+        .numOfCows(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -346,7 +346,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .userId(1L)
         .commonsId(2L)
         .totalWealth(0)
-        .numOfCows(1)
+        .numOfCows(0)
         .build();
 
     UserCommons ucSaved = UserCommons.builder()
@@ -354,7 +354,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .userId(1L)
         .commonsId(2L)
         .totalWealth(0)
-        .numOfCows(1)
+        .numOfCows(0)
         .build();
 
     String requestBody = mapper.writeValueAsString(uc);


### PR DESCRIPTION
In this PR, we recreate the changes made in PR92 from the 4pm codebase that fixed the initialization of the number of cows when joining a new commons as a user (previously numOfCows started at 1, now it begins at 0 cows). We also edit the corresponding tests for joining a new user commons to reflect this change.

Closes #94.

Original credit to: https://github.com/ucsb-cs156-s22/s22-4pm-happycows/pull/92