### PR TITLE
m22 - sk - (recreate 4pm PR85) to remove available commons list from homepage

### DIFF
--- a/frontend/src/main/pages/LoginPage.js
+++ b/frontend/src/main/pages/LoginPage.js
@@ -2,8 +2,6 @@ import React from "react";
 import { Container, Row, Col, Card, Button } from "react-bootstrap";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import CommonsList from "main/components/Commons/CommonsList";
-import { useBackend } from "main/utils/useBackend";
 import Background from './../../assets/HomePageBackground.jpg';
 
 const LoginCard = () => {
@@ -24,32 +22,19 @@ const LoginCard = () => {
 }
 
 export default function LoginPage() {
-  // Stryker disable all
-  const { data: commons } =
-    useBackend(
-      ["/api/commons/all"],
-      {
-        method: "GET",
-        url: "/api/commons/all"
-      },
-      []
-    );
-  // Stryker enable all
-
-
-  var listCommons = commons;
-  if (commons.length > 5) {
-    listCommons = commons.slice(0, 5);
-    listCommons.push({ id: "...", name: "..." });
-  }
-
+  
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
+    <div  style={
+      // Stryker disable next-line all : no need to unit test CSS
+      { backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
-        <Container style={{ marginTop: "8%" }}>
-          <Row style={{ alignItems: "center", justifyContent: "center" }}>
+        <Container style={
+          // Stryker disable next-line all : no need to unit test CSS
+          { marginTop: "8%" }}>
+          <Row style={
+            // Stryker disable next-line all : no need to unit test CSS
+            { alignItems: "center", justifyContent: "center" }}>
             <Col sm="auto"><LoginCard /></Col>
-            <Col sm="5"><CommonsList title="Available Commons" commonList={listCommons} buttonText={null} buttonLink={null} /></Col>
           </Row>
         </Container>
       </BasicLayout>

--- a/frontend/src/tests/pages/LoginPage.test.js
+++ b/frontend/src/tests/pages/LoginPage.test.js
@@ -5,7 +5,6 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import LoginPage from "main/pages/LoginPage";
-import commonsFixtures from "fixtures/commonsFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
@@ -36,10 +35,8 @@ describe("LoginPage tests", () => {
         expect(title.textContent).toEqual('Welcome to Happier Cows!');
     });
 
-    test("renders only a max of 6 elements in the list, despite there being 7 commons.", async () => {
-        apiCurrentUserFixtures.userOnly.user.commons = commonsFixtures.sevenCommons;
+    test("renders html elements", () => {
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.sevenCommons);
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -48,10 +45,5 @@ describe("LoginPage tests", () => {
             </QueryClientProvider>
         );
 
-        await screen.findAllByTestId("commonsCard-id");
-
-        const cards = screen.getAllByTestId("commonsCard-name");
-
-        expect(cards.length).toEqual(6);
     });
 });


### PR DESCRIPTION
In this PR, we remove the 'Available Commons' List from the Login Page for cleanliness (unnecessary information prior to user logging in). This is a recreation of the merged PR85 that is part of the 4pm codebase.

Closes #97. 

New login page:
<img width="1331" alt="Screen Shot 2022-06-24 at 3 27 07 PM" src="https://user-images.githubusercontent.com/72824248/175710217-af261764-d67e-4776-ae83-4d6a9c19dd3b.png">

Original credit to: https://github.com/ucsb-cs156-s22/s22-4pm-happycows/pull/85