### PR TITLE
m22 - sk - (recreate 5pm PR85) incorporate 5pm's 404 page not found into 6pm codebase

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
 import AdminListCommonsPage from "main/pages/AdminListCommonPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
+import NotFoundPage from "main/pages/NotFoundPage";
 
 function App() {
 
@@ -40,6 +41,7 @@ function App() {
         }
         <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
         <Route path="/play/:commonsId" element={<PlayPage />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -25,22 +25,27 @@ function App() {
         {
           !(hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<LoginPage />} />
         }
-        <Route path="/profile" element={<ProfilePage />} />
-        <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
         {
-          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/users" element={<AdminUsersPage />} />
+          hasRole(currentUser, "ROLE_ADMIN") && 
+          (
+            <>
+              <Route path="/admin/users" element={<AdminUsersPage />} />
+              <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
+              <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
+              <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
+            </>
+          )
         }
         {
-          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
+          hasRole(currentUser, "ROLE_USER") && 
+          (
+            <>
+             <Route path="/profile" element={<ProfilePage />} />
+             <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
+             <Route path="/play/:commonsId" element={<PlayPage />} />
+           </>
+          )
         }
-        {
-          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
-        }
-        {
-          hasRole(currentUser, "ROLE_ADMIN") && <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
-        }
-        <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
-        <Route path="/play/:commonsId" element={<PlayPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/main/pages/NotFoundPage.js
+++ b/frontend/src/main/pages/NotFoundPage.js
@@ -1,0 +1,14 @@
+
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function NotFoundPage() {
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>404 Error!</h1>
+                The Page You Are Looking For Does Not Exist Or You Do Not Have Access!
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/stories/pages/NotFoundPage.stories.js
+++ b/frontend/src/stories/pages/NotFoundPage.stories.js
@@ -1,0 +1,13 @@
+
+import React from 'react';
+
+import NotFoundPage from "main/pages/NotFoundPage";
+
+export default {
+    title: 'pages/NotFoundPage',
+    component: NotFoundPage
+};
+
+const Template = () => <NotFoundPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/pages/NotFoundPage.test.js
+++ b/frontend/src/tests/pages/NotFoundPage.test.js
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import NotFoundPage from "main/pages/NotFoundPage";
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+describe("NotFoundPage tests", () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(()=>{
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    });
+
+    test("renders correctly without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <NotFoundPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("404 Error!")).toBeInTheDocument();
+        expect(screen.getByText("The Page You Are Looking For Does Not Exist Or You Do Not Have Access!")).toBeInTheDocument();
+    });
+
+});


### PR DESCRIPTION
In this PR, we add 5pm's "catch-all" route 404 page when a route or page does not exist.

Appearance of 404 page when tested on localhost:
<img width="1361" alt="Screen Shot 2022-06-28 at 12 47 38 PM" src="https://user-images.githubusercontent.com/72824248/176272100-5efa2db0-9979-4d1d-9a45-68dec0bb1cfc.png">

Closes #99 

Original credit to: https://github.com/ucsb-cs156-s22/s22-5pm-happycows/pull/85