### PR TITLE
pc - add placeholder for Admin / Manage Jobs

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import ProfilePage from "main/pages/ProfilePage";
 import LeaderboardPage from "main/pages/LeaderboardPage";
 
 import AdminUsersPage from "main/pages/AdminUsersPage";
+import AdminJobsPage from "main/pages/AdminJobsPage";
 import AdminCreateCommonsPage from "main/pages/AdminCreateCommonsPage";
 import AdminEditCommonsPage from "main/pages/AdminEditCommonsPage";
 import AdminListCommonsPage from "main/pages/AdminListCommonPage";
@@ -30,6 +31,7 @@ function App() {
           (
             <>
               <Route path="/admin/users" element={<AdminUsersPage />} />
+              <Route path="/admin/jobs" element={<AdminJobsPage />} />
               <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
               <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
               <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -48,6 +48,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <NavDropdown title="Admin" id="appnavbar-admin-dropdown" data-testid="appnavbar-admin-dropdown" >
                     <NavDropdown.Item href="/admin/createcommons">Create Commons</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
+                    <NavDropdown.Item href="/admin/jobs">Manage Jobs</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/listcommons">List Commons</NavDropdown.Item>
                   </NavDropdown>
                 )

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -1,0 +1,14 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+const AdminJobsPage = () => {
+
+    return (
+        <BasicLayout>
+            <h2>Manage Jobs (Admins)</h2>
+            <p>Coming Soon; for now, you may use the Swagger endpoints to manage jobs.</p>
+        </BasicLayout>
+    );
+};
+
+export default AdminJobsPage;

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import AdminJobsPage from "main/pages/AdminJobsPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+describe("AdminJobsPage tests",  () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(()=>{
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+    });
+
+    test("renders without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminJobsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByText("Manage Jobs (Admins)")).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
# Overview

In this PR, we add a placeholder for a Manage Jobs page for admins

# US

* As an admin
* I can see a page for managing jobs
* So that I don't have to use swagger backend endpoints to manage jobs

The US for jobs is:
* As an admin
* I can initiate background processing for things such as milking the cows, adjusting cow health, etc.
* So that the game mechanics can continue even when no users are interacting with the web site.

# Issues Addressed

Closes #106 

# Before

![108-before](https://user-images.githubusercontent.com/1119017/176539009-7bb26832-4d39-44f9-88fa-d42d0304150d.gif)

# After

![108-after](https://user-images.githubusercontent.com/1119017/176538638-57971b1f-ab95-4ef6-8598-75a7c9ec976b.gif)
