### PR TITLE
m22 - sk - add sql query and backend route to get total users and total cows for a commons

### DIFF
--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -17,7 +17,7 @@ export default function CommonsTable({ commons, currentUser }) {
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
-        ["/api/commons/all"]
+        ["/api/commons/allplus"]
     );
     // Stryker enable all
 
@@ -31,43 +31,47 @@ export default function CommonsTable({ commons, currentUser }) {
     const columns = [
         {
             Header: 'id',
-            accessor: 'id', // accessor is the "key" in the data
+            accessor: 'commons.id', // accessor is the "key" in the data
 
         },
         {
             Header:'Name',
-            accessor: 'name',
+            accessor: 'commons.name',
         },
         {
             Header:'Cow Price',
-            accessor: row => String(row.cowPrice),
+            accessor: row => String(row.commons.cowPrice),
             id: 'cowPrice'
         },
         {
             Header:'Milk Price',
-            accessor: row => String(row.milkPrice),
+            accessor: row => String(row.commons.milkPrice),
             id: 'milkPrice'
         },
         {
             Header:'Starting Balance',
-            accessor: row => String(row.startingBalance),
+            accessor: row => String(row.commons.startingBalance),
             id: 'startingBalance'
         },
         {
             Header:'Starting Date',
-            accessor: row => String(row.startingDate).slice(0,10),
+            accessor: row => String(row.commons.startingDate).slice(0,10),
             id: 'startingDate'
         },
         {
             Header:'Degradation Rate',
             //accessor: row => row.startingDate.toString(),
-            accessor: row => String(row.degradationRate),
+            accessor: row => String(row.commons.degradationRate),
             id: 'degradationRate'
         },
         {
             Header:'Show Leaderboard?',
             id: 'showLeaderboard', // needed for tests
-            accessor: (row, _rowIndex) => String(row.showLeaderboard) // hack needed for boolean values to show up
+            accessor: (row, _rowIndex) => String(row.commons.showLeaderboard) // hack needed for boolean values to show up
+        },
+        {
+            Header: 'Cows',
+            accessor: 'totalCows'
         }
     ];
 

--- a/frontend/src/main/pages/AdminListCommonPage.js
+++ b/frontend/src/main/pages/AdminListCommonPage.js
@@ -11,8 +11,8 @@ export default function AdminListCommonsPage()
   // Stryker disable  all 
   const { data: commons, error: _error, status: _status } =
     useBackend(
-      ["/api/commons/all"],
-      { method: "GET", url: "/api/commons/all" },
+      ["/api/commons/allplus"],
+      { method: "GET", url: "/api/commons/allplus" },
       []
     );
   // Stryker enable  all 

--- a/src/main/java/edu/ucsb/cs156/happiercows/advice/HappierCowsControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/advice/HappierCowsControllerAdvice.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.happiercows.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class HappierCowsControllerAdvice {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public void handleIllegalArgumentException() {
+        log.error("IllegalArgumentException thrown");
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.controllers;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.ArrayList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
@@ -54,9 +56,74 @@ public class CommonsController extends ApiController {
   @GetMapping("/all")
   public ResponseEntity<String> getCommons() throws JsonProcessingException {
     log.info("getCommons()...");
-    Iterable<Commons> users = commonsRepository.findAll();
-    String body = mapper.writeValueAsString(users);
+    Iterable<Commons> commons = commonsRepository.findAll();
+    String body = mapper.writeValueAsString(commons);
     return ResponseEntity.ok().body(body);
+  }
+
+  // @ApiOperation(value = "Get a list of all commons and number of cows/users")
+  // @GetMapping("/allplus")
+  // public Iterable<CommonsPlus> getCommonsPlus() throws JsonProcessingException {
+  //   log.info("getCommonsPlus()...");
+  //   Iterable<Commons> commonsList = commonsRepository.findAll();
+    
+  //   ArrayList<CommonsPlus> commonsPlusList = new ArrayList<CommonsPlus>();
+
+  //  // NOTE: the following can probably be done much more efficiently using Java Streams 
+  // // and functional programming that uses a lambda to map a commons to a commonsPlus
+
+  //   for (Commons c : commonsList) {
+  //      Integer numCows = 0;
+  //      Long commonsId = c.getId();
+  //      Optional<Integer> numberOfCows = commonsRepository.getNumCows(commonsId);
+
+  //      if (numberOfCows.isPresent()) {
+  //        numCows = numberOfCows.get();
+  //      } 
+       
+  //      //int numUsers = commonsRepository.getNumUsers(c.id);
+  //      //commonsPlusList.add( new CommonsPlus(c, numCows, numUsers));
+  //      commonsPlusList.add( new CommonsPlus(c, numCows, commonsId));
+  //   }    
+
+  // return commonsPlusList;
+
+  // }
+
+  @ApiOperation(value = "Get a list of all commons and number of cows/users")
+  @GetMapping("/allplus")
+  public ResponseEntity<String> getCommonsPlus() throws JsonProcessingException {
+    log.info("getCommonsPlus()...");
+    Iterable<Commons> commonsList = commonsRepository.findAll();
+    
+    ArrayList<CommonsPlus> commonsPlusList = new ArrayList<CommonsPlus>();
+
+   // NOTE: the following can probably be done much more efficiently using Java Streams 
+  // and functional programming that uses a lambda to map a commons to a commonsPlus
+
+    for (Commons c : commonsList) {
+       Integer numCows = 0;
+       Integer numUsers = 0;
+       Long commonsId = c.getId();
+       Optional<Integer> numberOfCows = commonsRepository.getNumCows(commonsId);
+       Optional<Integer> numberOfUsers = commonsRepository.getNumUsers(commonsId);
+
+       if (numberOfCows.isPresent()) {
+         numCows = numberOfCows.get();
+       } 
+
+       if (numberOfUsers.isPresent()) {
+         numUsers = numberOfUsers.get();
+       } 
+       
+       //int numUsers = commonsRepository.getNumUsers(c.id);
+       //commonsPlusList.add( new CommonsPlus(c, numCows, numUsers));
+       commonsPlusList.add( new CommonsPlus(c, numCows, numUsers));
+    }
+
+    String body = mapper.writeValueAsString(commonsPlusList);
+    return ResponseEntity.ok().body(body);
+    // return commonsPlusList;
   }
 
   @ApiOperation(value = "Update a commons")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -78,19 +78,17 @@ public class CommonsController extends ApiController {
       status = HttpStatus.CREATED;
     }
 
-     if(params.getDegradationRate() < 0) { //disallowing negative values for degradation rate
-      updated.setDegradationRate(-1*params.getDegradationRate());
-     } else {
-      updated.setDegradationRate(params.getDegradationRate());
-     }
-
     updated.setName(params.getName());
     updated.setCowPrice(params.getCowPrice());
     updated.setMilkPrice(params.getMilkPrice());
     updated.setStartingBalance(params.getStartingBalance());
     updated.setStartingDate(params.getStartingDate());
     updated.setShowLeaderboard(params.getShowLeaderboard());
+    updated.setDegradationRate(params.getDegradationRate()); 
 
+    if(params.getDegradationRate() < 0){
+      throw new IllegalArgumentException("Degradation Rate cannot be negative");
+    }
     
 
     commonsRepository.save(updated);
@@ -126,8 +124,9 @@ public class CommonsController extends ApiController {
       .showLeaderboard(params.getShowLeaderboard())
       .build();
    
-    if(params.getDegradationRate() < 0) { //disallowing negative values for degradation rate
-      commons.setDegradationRate(-1*params.getDegradationRate());
+    //throw exception for degradation rate 
+    if(params.getDegradationRate() < 0){
+      throw new IllegalArgumentException("Degradation Rate cannot be negative");
     }
     
     Commons saved = commonsRepository.save(commons);

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import javax.persistence.*;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommonsPlus {
+    private Commons commons;
+    private Integer totalCows;
+    private Integer totalUsers;
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -31,6 +31,6 @@ public class CreateCommonsParams {
   @NumberFormat private double degradationRate;
   @DateTimeFormat
   private LocalDateTime startingDate;
-  private Boolean showLeaderboard; // NOTE: WHY DOES BOOLEAN HAVE TO BE CAPITALIZED HERE OMG THE AMOUNT OF GRIEF
-                                   // THIS GAVE ME-KZ
+  @Builder.Default
+  private Boolean showLeaderboard = false; 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
@@ -4,11 +4,17 @@ import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 
 
 @Repository
 public interface CommonsRepository extends CrudRepository<Commons, Long> {
+    @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commonsId=:commonsId")
+    Optional<Integer> getNumCows(Long commonsId);
 
+    @Query("SELECT COUNT(uc.userId) FROM user_commons uc WHERE uc.commonsId=:commonsId")
+    Optional<Integer> getNumUsers(Long commonsId);
+    
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -737,10 +737,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
         .andExpect(status().isOk()).andReturn();
 
-    //verify(commonsRepository, times(1)).findAll();
     verify(commonsRepository, times(1)).findAll();
-    verify(commonsRepository, times(1)).getNumCows(1L);
-    verify(commonsRepository, times(1)).getNumUsers(1L);
 
     String responseString = response.getResponse().getContentAsString();
     List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString, new TypeReference<List<CommonsPlus>>() {

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -44,6 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import edu.ucsb.cs156.happiercows.ControllerTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
@@ -712,4 +713,128 @@ public class CommonsControllerTests extends ControllerTestCase {
     }
   }
   
+  // // NEW
+  // @WithMockUser(roles = {"USER"})
+  // @Test
+  // public void getNumCowsFromCommonsIfCommonsExistAndPlayerJoined() throws Exception {
+  //   List<CommonsPlus> expectedCommonsList = new ArrayList<CommonsPlus>();
+  //   CommonsPlus Commons1 = CommonsPlus.builder().name("TestCommons1").build();
+
+  //   expectedCommons.add(Commons1);
+  //   when(commonsRepository.findAll()).thenReturn(expectedCommons);
+  //   MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
+  //       .andExpect(status().isOk()).andReturn();
+
+  //   verify(commonsRepository, times(1)).findAll();
+
+  //   String responseString = response.getResponse().getContentAsString();
+  //   List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
+  //   });
+  //   assertEquals(actualCommons, expectedCommons);
+    
+  //   Commons common = Commons.builder()
+  //     .name("TestCommons1")
+  //     .id(1L)
+  //     .build();
+
+  //   when(commonsRepository.findById(1L)).thenReturn(Optional.of(common));
+  //   when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(547));
+
+  //   MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
+  //       .andExpect(status().isOk()).andReturn();
+
+  //   verify(commonsRepository, times(1)).findById(1L);
+  //   verify(commonsRepository, times(1)).getNumCows(1L);
+
+  //   String responseString = response.getResponse().getContentAsString();
+  //   assertEquals(responseString, "547");
+  // }
+
+  // // NEW
+  // @WithMockUser(roles = {"USER"})
+  // @Test
+  // public void getNumCowsFromCommonsIfCommonsExistAndPlayerDidNotJoinYet() throws Exception {
+  //   Commons common = Commons.builder()
+  //     .name("TestCommons1")
+  //     .id(1L)
+  //     .build();
+
+  //   when(commonsRepository.findById(1L)).thenReturn(Optional.of(common));
+  //   when(commonsRepository.getNumCows(1L)).thenReturn(Optional.empty());
+
+  //   MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
+  //       .andExpect(status().isOk()).andReturn();
+
+  //   verify(commonsRepository, times(1)).findById(1L);
+  //   verify(commonsRepository, times(1)).getNumCows(1L);
+
+  //   String responseString = response.getResponse().getContentAsString();
+  //   assertEquals(responseString, "0");
+  // }
+
+  // // NEW
+  // @WithMockUser(roles = {"USER"})
+  // @Test
+  // public void getNumCowsFromCommonsIfCommonsDoesNotExist() throws Exception {
+  //   Commons common = Commons.builder()
+  //     .name("TestCommons1")
+  //     .id(1L)
+  //     .build();
+
+  //   when(commonsRepository.findById(1L)).thenReturn(Optional.empty());
+
+  //   MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
+  //       .andExpect(status().is(404)).andReturn();
+
+  //   verify(commonsRepository, times(1)).findById(1L);
+
+  //   Map<String, Object> responseMap = responseToJson(response);
+
+  //   assertEquals(responseMap.get("message"), "Commons with id 1 not found");
+  //   assertEquals(responseMap.get("type"), "EntityNotFoundException");
+
+  // }
+
+  //   @WithMockUser(roles = { "USER" })
+  // @Test
+  // public void getCommonsTest() throws Exception {
+  //   List<Commons> expectedCommons = new ArrayList<Commons>();
+  //   Commons Commons1 = Commons.builder().name("TestCommons1").build();
+
+  //   expectedCommons.add(Commons1);
+  //   when(commonsRepository.findAll()).thenReturn(expectedCommons);
+  //   MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
+  //       .andExpect(status().isOk()).andReturn();
+
+  //   verify(commonsRepository, times(1)).findAll();
+
+  //   String responseString = response.getResponse().getContentAsString();
+  //   List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
+  //   });
+  //   assertEquals(actualCommons, expectedCommons);
+  // }
+
+
+  // @WithMockUser(roles = { "USER" })
+  // @Test
+  // public void getCommonsPlusTest() throws Exception {
+  //   List<CommonsPlus> expectedCommonsPlus = new ArrayList<CommonsPlus>();
+  //   CommonsPlus CommonsPlus1 = Commons.builder()
+          // .totalCows(50)
+          // .commonsId(1L)
+          // .build();
+
+  //   expectedCommons.add(Commons1);
+  //   when(commonsRepository.findAll()).thenReturn(expectedCommons);
+  //   MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
+  //       .andExpect(status().isOk()).andReturn();
+
+  //   verify(commonsRepository, times(1)).findAll();
+
+  //   String responseString = response.getResponse().getContentAsString();
+  //   List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
+  //   });
+  //   assertEquals(actualCommons, expectedCommons);
+  // }
+
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -162,45 +162,45 @@ public class CommonsControllerTests extends ControllerTestCase {
   @WithMockUser(roles = { "ADMIN" })
   @Test
   public void createCommonsTest_withIllegalDegradationRate() throws Exception {
-    // LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
-    // Commons commons = Commons.builder()
-    //     .name("Jackson's Commons")
-    //     .cowPrice(500.99)
-    //     .milkPrice(8.99)
-    //     .startingBalance(1020.10)
-    //     .startingDate(someTime)
-    //     .degradationRate(-8.49)
-    //     .build();
+    Commons commons = Commons.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(-8.49)
+        .build();
 
-    // CreateCommonsParams parameters = CreateCommonsParams.builder()
-    //     .name("Jackson's Commons")
-    //     .cowPrice(500.99)
-    //     .milkPrice(8.99)
-    //     .startingBalance(1020.10)
-    //     .startingDate(someTime)
-    //     .degradationRate(-8.49)
-    //     .build();
+    CreateCommonsParams parameters = CreateCommonsParams.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(-8.49)
+        .build();
 
-    // String requestBody = objectMapper.writeValueAsString(parameters);
-    // String expectedResponse = objectMapper.writeValueAsString(commons);
+    String requestBody = objectMapper.writeValueAsString(parameters);
+    String expectedResponse = objectMapper.writeValueAsString(commons);
 
-    // when(commonsRepository.save(commons))
-    //     .thenReturn(commons);
+    when(commonsRepository.save(commons))
+        .thenReturn(commons);
 
-    // MvcResult response = mockMvc
-    //     .perform(post("/api/commons/new").with(csrf())
-    //         .contentType(MediaType.APPLICATION_JSON)
-    //         .characterEncoding("utf-8")
-    //         .content(requestBody))
-    //         .andExpect(status().isBadRequest()).andReturn();
+    MvcResult response = mockMvc
+        .perform(post("/api/commons/new").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+            .andExpect(status().isBadRequest()).andReturn();
 
-    //     Optional<IllegalArgumentException> someException = Optional
-    //     .ofNullable((IllegalArgumentException) response.getResolvedException());
+        Optional<IllegalArgumentException> someException = Optional
+        .ofNullable((IllegalArgumentException) response.getResolvedException());
 
 
-    // assertNotNull(someException.get());
-    //     assertTrue(someException.get() instanceof IllegalArgumentException);
+    assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
   }
 
   @WithMockUser(roles = { "USER" })
@@ -297,6 +297,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(8.49)
+        .showLeaderboard(false)
         .build();
 
     Commons commons = Commons.builder()
@@ -306,6 +307,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(8.49)
+        .showLeaderboard(false)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -358,6 +360,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(8.49)
+        .showLeaderboard(false)
         .build();
 
     Commons commons = Commons.builder()
@@ -367,6 +370,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(8.49)
+        .showLeaderboard(false)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -713,128 +713,39 @@ public class CommonsControllerTests extends ControllerTestCase {
     }
   }
   
-  // // NEW
-  // @WithMockUser(roles = {"USER"})
-  // @Test
-  // public void getNumCowsFromCommonsIfCommonsExistAndPlayerJoined() throws Exception {
-  //   List<CommonsPlus> expectedCommonsList = new ArrayList<CommonsPlus>();
-  //   CommonsPlus Commons1 = CommonsPlus.builder().name("TestCommons1").build();
 
-  //   expectedCommons.add(Commons1);
-  //   when(commonsRepository.findAll()).thenReturn(expectedCommons);
-  //   MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
-  //       .andExpect(status().isOk()).andReturn();
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void getCommonsPlusTest() throws Exception {
+    List<Commons> expectedCommons = new ArrayList<Commons>();
+    Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
+    expectedCommons.add(Commons1);
 
-  //   verify(commonsRepository, times(1)).findAll();
+    List<CommonsPlus> expectedCommonsPlus = new ArrayList<CommonsPlus>();
+    List<CommonsPlus> dummy = new ArrayList<CommonsPlus>();
+    CommonsPlus CommonsPlus1 = CommonsPlus.builder()
+          .commons(Commons1)
+          .totalCows(50)
+          .totalUsers(20)
+          .build();
 
-  //   String responseString = response.getResponse().getContentAsString();
-  //   List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
-  //   });
-  //   assertEquals(actualCommons, expectedCommons);
-    
-  //   Commons common = Commons.builder()
-  //     .name("TestCommons1")
-  //     .id(1L)
-  //     .build();
+    expectedCommonsPlus.add(CommonsPlus1);
+    when(commonsRepository.findAll()).thenReturn(expectedCommons);
+    when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(50));
+    when(commonsRepository.getNumUsers(1L)).thenReturn(Optional.of(20));
 
-  //   when(commonsRepository.findById(1L)).thenReturn(Optional.of(common));
-  //   when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(547));
+    MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
 
-  //   MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
-  //       .andExpect(status().isOk()).andReturn();
+    //verify(commonsRepository, times(1)).findAll();
+    verify(commonsRepository, times(1)).findAll();
+    verify(commonsRepository, times(1)).getNumCows(1L);
+    verify(commonsRepository, times(1)).getNumUsers(1L);
 
-  //   verify(commonsRepository, times(1)).findById(1L);
-  //   verify(commonsRepository, times(1)).getNumCows(1L);
-
-  //   String responseString = response.getResponse().getContentAsString();
-  //   assertEquals(responseString, "547");
-  // }
-
-  // // NEW
-  // @WithMockUser(roles = {"USER"})
-  // @Test
-  // public void getNumCowsFromCommonsIfCommonsExistAndPlayerDidNotJoinYet() throws Exception {
-  //   Commons common = Commons.builder()
-  //     .name("TestCommons1")
-  //     .id(1L)
-  //     .build();
-
-  //   when(commonsRepository.findById(1L)).thenReturn(Optional.of(common));
-  //   when(commonsRepository.getNumCows(1L)).thenReturn(Optional.empty());
-
-  //   MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
-  //       .andExpect(status().isOk()).andReturn();
-
-  //   verify(commonsRepository, times(1)).findById(1L);
-  //   verify(commonsRepository, times(1)).getNumCows(1L);
-
-  //   String responseString = response.getResponse().getContentAsString();
-  //   assertEquals(responseString, "0");
-  // }
-
-  // // NEW
-  // @WithMockUser(roles = {"USER"})
-  // @Test
-  // public void getNumCowsFromCommonsIfCommonsDoesNotExist() throws Exception {
-  //   Commons common = Commons.builder()
-  //     .name("TestCommons1")
-  //     .id(1L)
-  //     .build();
-
-  //   when(commonsRepository.findById(1L)).thenReturn(Optional.empty());
-
-  //   MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
-  //       .andExpect(status().is(404)).andReturn();
-
-  //   verify(commonsRepository, times(1)).findById(1L);
-
-  //   Map<String, Object> responseMap = responseToJson(response);
-
-  //   assertEquals(responseMap.get("message"), "Commons with id 1 not found");
-  //   assertEquals(responseMap.get("type"), "EntityNotFoundException");
-
-  // }
-
-  //   @WithMockUser(roles = { "USER" })
-  // @Test
-  // public void getCommonsTest() throws Exception {
-  //   List<Commons> expectedCommons = new ArrayList<Commons>();
-  //   Commons Commons1 = Commons.builder().name("TestCommons1").build();
-
-  //   expectedCommons.add(Commons1);
-  //   when(commonsRepository.findAll()).thenReturn(expectedCommons);
-  //   MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
-  //       .andExpect(status().isOk()).andReturn();
-
-  //   verify(commonsRepository, times(1)).findAll();
-
-  //   String responseString = response.getResponse().getContentAsString();
-  //   List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
-  //   });
-  //   assertEquals(actualCommons, expectedCommons);
-  // }
-
-
-  // @WithMockUser(roles = { "USER" })
-  // @Test
-  // public void getCommonsPlusTest() throws Exception {
-  //   List<CommonsPlus> expectedCommonsPlus = new ArrayList<CommonsPlus>();
-  //   CommonsPlus CommonsPlus1 = Commons.builder()
-          // .totalCows(50)
-          // .commonsId(1L)
-          // .build();
-
-  //   expectedCommons.add(Commons1);
-  //   when(commonsRepository.findAll()).thenReturn(expectedCommons);
-  //   MvcResult response = mockMvc.perform(get("/api/commons/all").contentType("application/json"))
-  //       .andExpect(status().isOk()).andReturn();
-
-  //   verify(commonsRepository, times(1)).findAll();
-
-  //   String responseString = response.getResponse().getContentAsString();
-  //   List<Commons> actualCommons = objectMapper.readValue(responseString, new TypeReference<List<Commons>>() {
-  //   });
-  //   assertEquals(actualCommons, expectedCommons);
-  // }
+    String responseString = response.getResponse().getContentAsString();
+    List<CommonsPlus> actualCommonsPlus = objectMapper.readValue(responseString, new TypeReference<List<CommonsPlus>>() {
+    });
+    assertEquals(actualCommonsPlus, expectedCommonsPlus);
+  }
 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -8,8 +8,10 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -29,9 +31,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -110,7 +115,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void createCommonsTest_invalid() throws Exception
+  public void createCommonsTest_zeroDegradation() throws Exception
   {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
@@ -120,7 +125,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .degradationRate(1.0)
+      .degradationRate(0)
       .showLeaderboard(false)
       .build();
 
@@ -130,7 +135,7 @@ public class CommonsControllerTests extends ControllerTestCase {
       .milkPrice(8.99)
       .startingBalance(1020.10)
       .startingDate(someTime)
-      .degradationRate(-1.0)
+      .degradationRate(0)
       .showLeaderboard(false)
       .build();
 
@@ -152,6 +157,50 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     String actualResponse = response.getResponse().getContentAsString();
     assertEquals(expectedResponse, actualResponse);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void createCommonsTest_withIllegalDegradationRate() throws Exception {
+    // LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+    // Commons commons = Commons.builder()
+    //     .name("Jackson's Commons")
+    //     .cowPrice(500.99)
+    //     .milkPrice(8.99)
+    //     .startingBalance(1020.10)
+    //     .startingDate(someTime)
+    //     .degradationRate(-8.49)
+    //     .build();
+
+    // CreateCommonsParams parameters = CreateCommonsParams.builder()
+    //     .name("Jackson's Commons")
+    //     .cowPrice(500.99)
+    //     .milkPrice(8.99)
+    //     .startingBalance(1020.10)
+    //     .startingDate(someTime)
+    //     .degradationRate(-8.49)
+    //     .build();
+
+    // String requestBody = objectMapper.writeValueAsString(parameters);
+    // String expectedResponse = objectMapper.writeValueAsString(commons);
+
+    // when(commonsRepository.save(commons))
+    //     .thenReturn(commons);
+
+    // MvcResult response = mockMvc
+    //     .perform(post("/api/commons/new").with(csrf())
+    //         .contentType(MediaType.APPLICATION_JSON)
+    //         .characterEncoding("utf-8")
+    //         .content(requestBody))
+    //         .andExpect(status().isBadRequest()).andReturn();
+
+    //     Optional<IllegalArgumentException> someException = Optional
+    //     .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+
+    // assertNotNull(someException.get());
+    //     assertTrue(someException.get() instanceof IllegalArgumentException);
   }
 
   @WithMockUser(roles = { "USER" })
@@ -215,6 +264,8 @@ public class CommonsControllerTests extends ControllerTestCase {
 
     parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
     commons.setMilkPrice(parameters.getMilkPrice());
+    parameters.setDegradationRate(parameters.getDegradationRate() + 1.00);
+    commons.setDegradationRate(parameters.getDegradationRate());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -236,63 +287,127 @@ public class CommonsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN" })
   @Test
-  public void updateCommonsTest_invalid() throws Exception
-  {
+  public void updateCommonsTest_withDegradationRate_Zero() throws Exception {
     LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .degradationRate(-1.0)
-      .showLeaderboard(false)
-      .build();
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
 
     Commons commons = Commons.builder()
-      .name("Jackson's Commons")
-      .cowPrice(500.99)
-      .milkPrice(8.99)
-      .startingBalance(1020.10)
-      .startingDate(someTime)
-      .degradationRate(1.0)
-      .showLeaderboard(false)
-      .build();
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
 
     when(commonsRepository.save(commons))
-      .thenReturn(commons);
+        .thenReturn(commons);
 
     mockMvc
       .perform(put("/api/commons/update?id=0").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
+          .contentType(MediaType.APPLICATION_JSON)
+          .characterEncoding("utf-8")
+          .content(requestBody))
       .andExpect(status().isCreated());
 
     verify(commonsRepository, times(1)).save(commons);
 
     parameters.setMilkPrice(parameters.getMilkPrice() + 3.00);
     commons.setMilkPrice(parameters.getMilkPrice());
+    parameters.setDegradationRate(0);
+    commons.setDegradationRate(parameters.getDegradationRate());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
     when(commonsRepository.findById(0L))
-      .thenReturn(Optional.of(commons));
+        .thenReturn(Optional.of(commons));
 
     when(commonsRepository.save(commons))
-      .thenReturn(commons);
+        .thenReturn(commons);
 
     mockMvc
       .perform(put("/api/commons/update?id=0").with(csrf())
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding("utf-8")
-        .content(requestBody))
+          .contentType(MediaType.APPLICATION_JSON)
+          .characterEncoding("utf-8")
+          .content(requestBody))
       .andExpect(status().isNoContent());
 
     verify(commonsRepository, times(1)).save(commons);
+  }
+
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void updateCommonsTest_withIllegalDegradationRate() throws Exception {
+    LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+    CreateCommonsParams parameters = CreateCommonsParams.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
+
+    Commons commons = Commons.builder()
+        .name("Jackson's Commons")
+        .cowPrice(500.99)
+        .milkPrice(8.99)
+        .startingBalance(1020.10)
+        .startingDate(someTime)
+        .degradationRate(8.49)
+        .build();
+
+    String requestBody = objectMapper.writeValueAsString(parameters);
+
+    when(commonsRepository.save(commons))
+        .thenReturn(commons);
+
+    mockMvc
+        .perform(put("/api/commons/update?id=0").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isCreated());
+
+    verify(commonsRepository, times(1)).save(commons);
+
+    parameters.setDegradationRate(-10);
+    commons.setDegradationRate(parameters.getDegradationRate());
+
+    requestBody = objectMapper.writeValueAsString(parameters);
+
+    when(commonsRepository.findById(0L))
+        .thenReturn(Optional.of(commons));
+
+    when(commonsRepository.save(commons))
+        .thenReturn(commons);
+
+    MvcResult response = mockMvc
+        .perform(put("/api/commons/update?id=0").with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody))
+        .andExpect(status().isBadRequest()).andReturn();
+
+    Optional<IllegalArgumentException> someException = Optional
+        .ofNullable((IllegalArgumentException) response.getResolvedException());
+
+
+
+    assertNotNull(someException.get());
+        assertTrue(someException.get() instanceof IllegalArgumentException);
   }
 
   //This common SHOULD be in the repository
@@ -333,7 +448,7 @@ public class CommonsControllerTests extends ControllerTestCase {
     assertEquals(responseMap.get("type"), "EntityNotFoundException");
   }
 
-  @WithMockUser(roles = { "USER"})
+  @WithMockUser(roles = { "USER" })
   @Test
   public void joinCommonsTest() throws Exception {
 


### PR DESCRIPTION
Replaced by: https://github.com/ucsb-cs156/proj-happycows/pull/2

# Overview

In this PR, we create a new object CommonsPlus that, in addition to a given commons, contains two additional fields: `totalCows` and `totalUsers`. 

We add a SQL query to query the user commons table for the two values of interest (total number of cows and users in a commons) and a corresponding endpoint/api route to return the CommonsPlus objects with the number of cows/users.

We refactor the implementation of the getCommonsPlus method in CommonsController to use functional programming (java streams with lambdas), making the implementation of this method straightforward and efficient. 

Demonstrating the `api/commons/allplus` endpoint:
<img width="1427" alt="Screen Shot 2022-07-11 at 5 38 21 PM" src="https://user-images.githubusercontent.com/72824248/178381748-80cfdfab-03c4-4a5f-b29b-017acbebe8b6.png">

Closes #112 #102 and #98 

Further testing will be done on Heroku QA deployment.